### PR TITLE
Minor: ran cargo clippy --fix

### DIFF
--- a/rustdss_core/src/db_logic/lists.rs
+++ b/rustdss_core/src/db_logic/lists.rs
@@ -90,7 +90,7 @@ pub fn lrange(state: &CoreState, key: &Key, start: i64, end: i64) -> RespData {
         // We want the offset from the start
         let start_offset = start_front_or_back(total, start);
         if end >= 0 {
-            (end - start_offset as i64) as usize + 1
+            (end - start_offset) as usize + 1
         } else {
             println!("debug: {}", end);
             let end_abs = start_front_or_back(total, end);
@@ -109,8 +109,7 @@ pub fn lrange(state: &CoreState, key: &Key, start: i64, end: i64) -> RespData {
                 let result: VecDeque<RespData> = inner_list
                     .iter()
                     .skip(start_front_or_back(total, start) as usize)
-                    .take(end_front_or_back(total, start, end))
-                    .map(|item| item.clone()) // ew gross - could be v expensive!
+                    .take(end_front_or_back(total, start, end)).cloned() // ew gross - could be v expensive!
                     .collect();
 
                 //

--- a/rustdss_core/src/db_logic/number.rs
+++ b/rustdss_core/src/db_logic/number.rs
@@ -63,7 +63,7 @@ mod incr_should {
         let response1 = incr(&mut state, "key".into(), None);
         let response2 = incr(&mut state, "key".into(), Some(2));
 
-        assert_eq!(state.keyval.get("key".into()), Some(&RespData::Number(8)));
+        assert_eq!(state.keyval.get("key"), Some(&RespData::Number(8)));
         assert_eq!(response1, RespData::Number(6));
         assert_eq!(response2, RespData::Number(8));
     }
@@ -85,12 +85,12 @@ mod incr_should {
 
         assert_eq!(response1, RespData::Number(28));
         assert_eq!(response2, RespData::Number(30));
-        assert_eq!(state.keyval.get("key1".into()), Some(&RespData::Number(30)));
+        assert_eq!(state.keyval.get("key1"), Some(&RespData::Number(30)));
 
         assert_eq!(response3, RespData::Error("NaN".into()));
         assert_eq!(response4, RespData::Error("NaN".into()));
         assert_eq!(
-            state.keyval.get("key2".into()),
+            state.keyval.get("key2"),
             Some(&RespData::SimpleStr("not_a_number".into()))
         );
     }
@@ -106,7 +106,7 @@ mod incr_should {
 
         assert_eq!(response1, RespData::Number(1));
         assert_eq!(response2, RespData::Number(5));
-        assert_eq!(state.keyval.get("key".into()), Some(&RespData::Number(5)));
+        assert_eq!(state.keyval.get("key"), Some(&RespData::Number(5)));
     }
 }
 
@@ -124,7 +124,7 @@ mod decr_should {
         let response1 = decr(&mut state, "key".into(), None);
         let response2 = decr(&mut state, "key".into(), Some(2));
 
-        assert_eq!(state.keyval.get("key".into()), Some(&RespData::Number(2)));
+        assert_eq!(state.keyval.get("key"), Some(&RespData::Number(2)));
         assert_eq!(response1, RespData::Number(4));
         assert_eq!(response2, RespData::Number(2));
     }
@@ -146,12 +146,12 @@ mod decr_should {
 
         assert_eq!(response1, RespData::Number(26));
         assert_eq!(response2, RespData::Number(24));
-        assert_eq!(state.keyval.get("key1".into()), Some(&RespData::Number(24)));
+        assert_eq!(state.keyval.get("key1"), Some(&RespData::Number(24)));
 
         assert_eq!(response3, RespData::Error("NaN".into()));
         assert_eq!(response4, RespData::Error("NaN".into()));
         assert_eq!(
-            state.keyval.get("key2".into()),
+            state.keyval.get("key2"),
             Some(&RespData::SimpleStr("not_a_number".into()))
         );
     }
@@ -167,6 +167,6 @@ mod decr_should {
 
         assert_eq!(response1, RespData::Number(-1));
         assert_eq!(response2, RespData::Number(-5));
-        assert_eq!(state.keyval.get("key".into()), Some(&RespData::Number(-5)));
+        assert_eq!(state.keyval.get("key"), Some(&RespData::Number(-5)));
     }
 }

--- a/rustdss_core/src/lib.rs
+++ b/rustdss_core/src/lib.rs
@@ -32,7 +32,7 @@ impl Core {
                     let response = base_logic::core_logic(&mut db_state, cmd);
                     responder
                         .send(response)
-                        .expect(format!("[core::{}] can't reply to messages", db_id).as_str());
+                        .unwrap_or_else(|_| panic!("[core::{}] can't reply to messages", db_id));
                 } else {
                     println!("[core::{}] db_core died/dropped?", db_id);
                     break;
@@ -77,7 +77,7 @@ impl Core {
                 }
             }
         });
-        Self { sender: sender }
+        Self { sender }
     }
 
     pub fn get_sender(&self) -> Sender<Message> {

--- a/rustdss_server/src/connection/mod.rs
+++ b/rustdss_server/src/connection/mod.rs
@@ -10,7 +10,7 @@ use std::thread;
 pub struct Connection {}
 
 impl Connection {
-    fn handle_incoming_stream(core_sender: Sender<Message>, stream: &mut TcpStream) -> () {
+    fn handle_incoming_stream(core_sender: Sender<Message>, stream: &mut TcpStream) {
         // This function will create and use instances of Request
         println!("[connection], handling tcp stream from client {:?}", stream);
 

--- a/rustdss_server/src/request/command.rs
+++ b/rustdss_server/src/request/command.rs
@@ -20,7 +20,7 @@ fn numerical_arg(data: Option<RespData>) -> Option<i64> {
             _ => None,
         })
         .or_else(|| {
-            let number: Option<i64> = string_arg(data).map(|s| s.parse().ok()).flatten();
+            let number: Option<i64> = string_arg(data).and_then(|s| s.parse().ok());
             number
         })
 }

--- a/rustdss_transport/src/deserialise.rs
+++ b/rustdss_transport/src/deserialise.rs
@@ -69,7 +69,6 @@ impl DeserialiseRespData for RespData {
                     Ok(i) => {
                         // Read the following number of VALUES, not chunks!!
                         let vals: VecDeque<Self> = (0..i)
-                            .into_iter()
                             .map(|_| {
                                 // Read the next value from the stream
                                 // TODO: Handle this error properly - we don't want any panics in
@@ -101,7 +100,7 @@ where
     if first_chunk.parse::<i64>() == Ok(-1) {
         RespData::NullString
     } else if let Some(second_chunk) = parse_chunk(stream) {
-        RespData::BulkStr(second_chunk.into())
+        RespData::BulkStr(second_chunk)
     } else {
         RespData::Error("Can't process bulk string".into())
     }

--- a/rustdss_transport/src/serialise.rs
+++ b/rustdss_transport/src/serialise.rs
@@ -11,7 +11,7 @@ fn serialise_list(items: &VecDeque<RespData>) -> String {
     // optimised at some point
     let len = items.len();
 
-    let content: String = items.into_iter().map(|item| item.as_string()).collect();
+    let content: String = items.iter().map(|item| item.as_string()).collect();
 
     format!("*{}\r\n{}", len, content)
 }


### PR DESCRIPTION
Nothing major 

* "into_iter()": In a few places - Clippy identified that there is not need to take ownership.

* Was manually implementing .cloned()

```rustlang
                 let result: VecDeque<RespData> = inner_list
                     .iter()
                     .skip(start_front_or_back(total, start) as usize)
-                    .take(end_front_or_back(total, start, end))
-                    .map(|item| item.clone()) // ew gross - could be v expensive!
+                    .take(end_front_or_back(total, start, end)).cloned() // ew gross - could be v expensive!
                     .collect();
```